### PR TITLE
MyEnum group_by/3 ,intersperse/2, into/2 , join/2 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # MyEnum
+
+### 아직 구현하지 못한 함수 목록
+
+-   chunk_by/2
+-   chunk_every/2
+-   chunk_every/4
+-   chunk_while/4

--- a/lib/my_enum.ex
+++ b/lib/my_enum.ex
@@ -403,4 +403,80 @@ defmodule MyEnum do
       value -> frequencies_by(t, key_function, Map.put(result, new_key, value + 1))
     end
   end
+
+  @doc """
+    group_by/3 제공한 key_function 함수를 사용하여 요소를 적용하여 나온 Key를 만족하는 요소들을 그룹화하고
+    제공한 value_fun으로 value에 저장되는 요소를 변환 시킵니다. value_fun을 제공하지 않을경우에는 default 값으로
+    fn x -> x end 값이 들어갑니다.
+  """
+
+  def group_by(list, key_function, value_function \\ fn x -> x end)
+
+  def group_by(list, key_function, value_function),
+    do: group_by(list, key_function, value_function, %{})
+
+  defp group_by([], _key_function, _value_function, result), do: result
+
+  defp group_by([h | t], key_function, value_function, result) do
+    new_key = key_function.(h)
+    new_value = value_function.(h)
+    value = result[new_key]
+
+    case value do
+      nil ->
+        group_by(t, key_function, value_function, Map.put(result, new_key, [new_value]))
+
+      value ->
+        group_by(t, key_function, value_function, Map.put(result, new_key, value ++ [new_value]))
+    end
+  end
+
+  @doc """
+    intersperse/2 리스트 요소 사이에 구분자를 넣습니다.
+    요소가 하나일 경우에는 바로 반환합니다 [1] ==> [1]
+    요소가 빈 경우 []를 반환합니다.
+  """
+
+  def intersperse(list, seperator), do: intersperse(list, seperator, 0, [])
+  defp intersperse([], _sperator, _depth, result), do: result
+
+  defp intersperse([h | t], seperator, depth, result) do
+    case rem(depth, 2) == 0 do
+      true -> intersperse(t, seperator, depth + 1, result ++ [h])
+      false -> intersperse([h | t], seperator, depth + 1, result ++ [seperator])
+    end
+  end
+
+  @doc """
+    into/3 리스트의 요소에서 함수를 적용하여 나온값을 주어진 colletable에 변환하여 넣습니다.
+  """
+  def into([], colletable), do: colletable
+  def into([h | t], colletable) when is_list(colletable), do: into(t, colletable ++ [h])
+
+  def into([h | t], colletable) when is_map(colletable) do
+    {k, v} = h
+    new_map = Map.put(colletable, k, v)
+    into(t, new_map)
+  end
+
+  # map의 키를 바인딩 하는 방법을 몰라서 comprehension으로 구현했습니다.
+  # 리뷰 부탁드립니다 !!
+  def into(map, colletable) when is_map(map) do
+    for {k, v} <- map, into: colletable, do: {k, v}
+  end
+
+  @doc """
+    join/2 구분 기호로 사용하여 주어진 joiner로 요소들을 문자열로 결합합니다.
+    joiner가 주어지지 않으면 default 값인 "" 빈 문자열이 사용됩니다.
+    모든 요소는 문자열로 변환할 수 있어야 합니다.
+  """
+  def join(list, joiner \\ ""), do: join(list, joiner, 0, "")
+  defp join([], _joiner, _depth, result), do: result
+
+  defp join([h | t], joiner, depth, result) do
+    case rem(depth, 2) == 0 do
+      true -> join(t, joiner, depth + 1, result <> "#{h}")
+      false -> join([h | t], joiner, depth + 1, result <> joiner)
+    end
+  end
 end

--- a/test/my_enum_test.exs
+++ b/test/my_enum_test.exs
@@ -496,4 +496,93 @@ defmodule MyEnumTest do
                )
     end
   end
+
+  describe "MyEnum.group_by/3 tests" do
+    test "제공한 리스트가 비어있다면 %{} 를 반환한다." do
+      assert %{} == MyEnum.group_by([], fn x -> x end)
+    end
+
+    test "key_function에 요소를 적용하여 얻은 Key 결과가 같은 요소끼리 그룹화 하여 반환합니다. " do
+      assert %{3 => ["asd", "one"], 4 => ["four"], 5 => ["three"]} ==
+               MyEnum.group_by(["asd", "one", "three", "four"], &String.length/1)
+    end
+
+    test "key_function에 요소를 적용하여 얻은 Key 결과가 같은 요소끼리 그룹화 하여 반환합니다.2 " do
+      assert %{0 => [2, 2, 4, 4, 6, 8], 1 => [1, 3, 5, 7, 7, 9]} ==
+               MyEnum.group_by([1, 2, 2, 3, 4, 4, 5, 6, 7, 7, 8, 9], fn x -> rem(x, 2) end)
+    end
+
+    test "key_function에 요소를 적용하여 얻은 Key 결과가 같은 요소를 value_function을 적용하여 반환합니다. " do
+      assert %{3 => ["a", "o"], 4 => ["f"], 5 => ["t"]} ==
+               MyEnum.group_by(["asd", "one", "three", "four"], &String.length/1, &String.first/1)
+    end
+
+    test "key_function에 요소를 적용하여 얻은 Key 결과가 같은 요소를 value_function을 적용하여 반환합니다.2 " do
+      assert %{0 => [4, 4, 16, 16, 36, 64], 1 => [1, 9, 25, 49, 49, 81]} ==
+               MyEnum.group_by(
+                 [1, 2, 2, 3, 4, 4, 5, 6, 7, 7, 8, 9],
+                 fn x -> rem(x, 2) end,
+                 fn x -> x * x end
+               )
+    end
+  end
+
+  describe "MyEnum.intersperse/2 tests" do
+    test "제공한 리스트가 비어있다면 []를 반환합니다." do
+      assert [] == MyEnum.intersperse([], 0)
+    end
+
+    test "제공한 리스트의 요소가 하나라면 리스트를 바로 반환합니다." do
+      assert [1] == MyEnum.intersperse([1], 0)
+    end
+
+    test "제공한 리스트의 요소 사이에 구분자를 넣습니다." do
+      assert [1, 0, 2, 0, 3, 0, 4, 0, 5] == MyEnum.intersperse([1, 2, 3, 4, 5], 0)
+    end
+
+    test "제공한 리스트의 요소 사이에 구분자를 넣습니다.2" do
+      assert [1, "seperator", 2, "seperator", 3, "seperator", 4, "seperator", 5] ==
+               MyEnum.intersperse([1, 2, 3, 4, 5], "seperator")
+    end
+  end
+
+  describe "MyEnum.into/3 tests" do
+    test "제공한 리스트가 비어있다면 colletable을 반환합니다." do
+      colletable = %{a: 1, b: 2, c: 3}
+      assert colletable == MyEnum.into([], colletable)
+    end
+
+    test "list가 제공되고 colletable이 list일때 colletable에 리스트 요소를 넣어 반환합니다." do
+      colletable = [4, 5, 6]
+      assert [4, 5, 6, 1, 2, 3] == MyEnum.into([1, 2, 3], colletable)
+    end
+
+    test "keyword list가 제공되고 colletable이 map일때 colletable에 리스트 요소를 넣어 반환합니다." do
+      colletable = %{a: 5}
+      assert %{a: 1, b: 2, c: 3} == MyEnum.into([a: 1, b: 2, c: 3], colletable)
+    end
+
+    test "map이 제공되고 colletable이 list일때 colletable에 map 요소를 넣어 반환합니다." do
+      assert [{0, [1, 2, 3]}, {:a, 1}] == MyEnum.into(%{0 => [1, 2, 3], a: 1}, [])
+    end
+
+    test "map이 제공되고 colletable이 map일때 colletable에 map 요소를 넣어 반환합니다." do
+      assert %{0 => [1, 2, 3], :a => 1, :b => 2} ==
+               MyEnum.into(%{0 => [1, 2, 3], a: 1}, %{0 => [1], a: 4, b: 2})
+    end
+  end
+
+  describe "MyEnum.join/2 tests" do
+    test "빈 리스트가 주어지면 빈 문자열을 반환합니다" do
+      assert "" == MyEnum.join([], "is_empty")
+    end
+
+    test "리스트만 주어지면 하나의 문자열로 반환합니다." do
+      assert "123" == MyEnum.join([1, 2, 3])
+    end
+
+    test "리스트와 joiner가 주어지면 joiner를 구분자로 하여 하나의 문자열을 반환합니다." do
+      assert "1 / 2 / 3" == MyEnum.join([1, 2, 3], " / ")
+    end
+  end
 end


### PR DESCRIPTION
질문 1. map 안의 요소들의 키를 순차적으로 패턴매칭하는 방법이 궁금합니다! 
질문 2. 해당 명령문을 수행할 때 받는 경고입니다.
iex(9)> Enum.into(%{0 => [1,2,3], a: 1}, [4,5,6])   // 키워드 리스트와 리스트를 합쳐서 발생하는 경고 같은데 맞을까요 ? 
제가 구현한 MyEnum.into에서도 똑같이 경고가 발생됩니다.